### PR TITLE
Feat: Display current version of Payload the admin panel is using

### DIFF
--- a/src/components/IconGraphic/index.tsx
+++ b/src/components/IconGraphic/index.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+
+const css = `
+  .graphic-icon path {
+    fill: var(--theme-elevation-1000);
+  }
+
+  .graphic-icon .version {
+    color: var(--theme-elevation-400);
+    margin: 0;
+    margin-top: 10px;
+    text-decoration: underline;
+    text-decoration-color: var(--theme-bg);
+  }
+`;
+
+const PayloadIcon: React.FC = () => (
+  <svg
+    width="25"
+    height="25"
+    viewBox="0 0 25 25"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M11.5293 0L23 6.90096V19.9978L14.3608 25V11.9032L2.88452 5.00777L11.5293 0Z"
+    />
+    <path
+      d="M10.6559 24.2727V14.0518L2 19.0651L10.6559 24.2727Z"
+    />
+  </svg>
+);
+
+export const Icon:React.FC = () => {
+  const [version, setVersion] = React.useState();
+
+  React.useEffect(() => {
+    const fetchVersion = async () => {
+      const res = await fetch('/api/payload-version');
+      if (res.status === 200) {
+        const { version } = await res.json();
+        console.log(typeof version)
+        setVersion(version.replace(/[^0-9.]/g, ''));
+      }
+    }
+
+    fetchVersion();
+  }, []);
+
+  return (
+    <React.Fragment>
+      <style>
+        {css}
+      </style>
+      <div className="graphic-icon">
+        <PayloadIcon />
+        {version && <p className="version">v{version}</p>}
+      </div>
+    </React.Fragment>
+  );
+}

--- a/src/endpoints/readPayloadVersion.ts
+++ b/src/endpoints/readPayloadVersion.ts
@@ -1,8 +1,11 @@
 import fs from 'fs';
 import path from 'path';
 import { PayloadHandler } from 'payload/config';
+import { Forbidden } from 'payload/errors';
 
 export const readPayloadVersion: PayloadHandler = (req, res, next) => {
+  if (!req.user) throw new Forbidden
+
   try {
     const data: any = fs.readFileSync(path.resolve(__dirname, '../../package.json'));
     const packageJson = JSON.parse(data);

--- a/src/endpoints/readPayloadVersion.ts
+++ b/src/endpoints/readPayloadVersion.ts
@@ -1,0 +1,16 @@
+import fs from 'fs';
+import path from 'path';
+import { PayloadHandler } from 'payload/config';
+
+export const readPayloadVersion: PayloadHandler = (req, res, next) => {
+  try {
+    const data: any = fs.readFileSync(path.resolve(__dirname, '../../package.json'));
+    const packageJson = JSON.parse(data);
+    res.status(200).json({
+      version: packageJson.dependencies.payload
+    });
+  } catch (err) {
+    console.error(err)
+    res.status(500).json({ version: undefined })
+  }
+}

--- a/src/mocks/serverModule.js
+++ b/src/mocks/serverModule.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -14,10 +14,14 @@ import BeforeLogin from './components/BeforeLogin';
 import AfterDashboard from "./components/AfterDashboard";
 import { Alerts } from './collections/Alerts'
 import BeforeDashboard from './components/BeforeDashboard';
+import { readPayloadVersion } from './endpoints/readPayloadVersion';
+import { Icon } from './components/IconGraphic';
 
 dotenv.config({
   path: path.resolve(__dirname, '../.env'),
 });
+
+const mockModulePath = path.resolve(__dirname, './mocks/serverModule.js');
 
 // the payload config is the entrypoint for configuring the entire application
 // all the API REST, GraphQL, authentication, file uploads, data layer and admin UI is built from the config
@@ -33,6 +37,9 @@ export default buildConfig({
 
     // custom components added to show demo info
     components: {
+      graphics: {
+        Icon: Icon,
+      },
       beforeLogin: [
         BeforeLogin,
       ],
@@ -43,6 +50,18 @@ export default buildConfig({
         AfterDashboard,
       ],
     },
+
+    // alias modules that should **only** be used in server context, not within the frontend code
+    webpack: (config) => ({
+      ...config,
+      resolve: {
+        ...config.resolve,
+        alias: [path.resolve(__dirname, 'endpoints/readPayloadVersion')].reduce((alias, aliasPath) => ({
+          ...alias,
+          [aliasPath]: mockModulePath,
+        }), config.resolve.alias),
+      },
+    }),
   },
 
   // collections in Payload are synonymous with database tables, models or entities from other frameworks and systems
@@ -121,6 +140,14 @@ export default buildConfig({
       'de'
     ],
   },
+
+  endpoints: [
+    {
+      method: 'get',
+      path: '/payload-version',
+      handler: readPayloadVersion
+    }
+  ],
 
   typescript: {
     outputFile: path.resolve(__dirname, 'payload-types.ts')


### PR DESCRIPTION
Notes version below main Icon.

I also had to add webpack aliasing and a custom endpoint. I think that is fine, and can be an example of how to do some of these things.


![Screen Shot 2022-12-06 at 12 40 01 PM](https://user-images.githubusercontent.com/30633324/205983349-66bcd0e4-cab5-4bce-a581-22cb5b5018c2.png)