### PR TITLE
fix: adds required hero field to homeData

### DIFF
--- a/src/data/pages/homeData.ts
+++ b/src/data/pages/homeData.ts
@@ -12,6 +12,56 @@ export const getHomeData = (imageId: string, userId: string): Partial<Page> => {
         'Here is a column of content and it has an embedded Media element within it. This content will be used to generate a Meta Description.',
       image: imageId,
     },
+    hero: {
+      type: 'contentMedia',
+      contentMedia: {
+        richText: [
+          {
+            type: 'h1',
+            children: [
+              {
+                text: 'Payload Manifest',
+              },
+            ],
+          },
+          {
+            type: 'large-body',
+            children: [
+              {
+                text: 'This is a snippet of introductory text set in a custom rich-text element called "large body". ',
+              },
+            ],
+          },
+          {
+            type: 'p',
+            children: [
+              {
+                text: 'Here is a regular paragraph with a ',
+              },
+              {
+                type: 'link',
+                url: 'https://payloadcms.com',
+                newTab: false,
+                children: [
+                  {
+                    text: 'link',
+                  },
+                ],
+              },
+              {
+                text: '.',
+              },
+            ],
+          },
+        ],
+        links: [],
+        media: imageId,
+        // @ts-expect-error
+        embeddedVideo: {
+          aspectRatio: '56.25',
+        },
+      },
+    },
     layout: [
       {
         columns: [


### PR DESCRIPTION
The pages hero field has a required `type` field. 

`homeData` found at `src/data/pages/homeData.ts` was not adding the `hero` field and therefore the cron was unable to properly `seed` and `reset` the DB. 

![Screen Shot 2023-09-20 at 10 58 44 AM](https://github.com/payloadcms/public-demo/assets/35232443/4cec360f-652a-464d-912e-63d0cb989870)

This PR adds the hero data for `homeData`.
