### PR TITLE
feat: prevent admin user updating email

### DIFF
--- a/src/payload/collections/Users/hooks/sanitizeDemoAdmin.ts
+++ b/src/payload/collections/Users/hooks/sanitizeDemoAdmin.ts
@@ -10,9 +10,7 @@ export const sanitizeDemoAdmin: BeforeOperationHook = ({ args, operation }) => {
       'password' in args.data &&
       args.req.user.email === adminEmail
     ) {
-      args.data.email = adminEmail
       args.data.password = adminPassword
-      args.data.passwordConfirm = adminPassword
     }
   }
 

--- a/src/payload/collections/Users/index.ts
+++ b/src/payload/collections/Users/index.ts
@@ -1,10 +1,12 @@
 import type { CollectionConfig } from 'payload/types'
+import { email as validateEmail } from 'payload/dist/fields/validations'
 
 import { admins } from '../../access/admins'
 import { checkRole } from './checkRole'
 import { ensureFirstUserIsAdmin } from './hooks/ensureFirstUserIsAdmin'
 import { loginAfterCreate } from './hooks/loginAfterCreate'
 import { sanitizeDemoAdmin } from './hooks/sanitizeDemoAdmin'
+import { adminEmail } from '../../cron/shared'
 
 const Users: CollectionConfig = {
   access: {
@@ -21,6 +23,18 @@ const Users: CollectionConfig = {
     {
       name: 'name',
       type: 'text',
+    },
+    {
+      // override default email field to add a custom validate function to prevent users from changing the login email
+      name: 'email',
+      type: 'email',
+      validate: (value, args) => {
+        if (args?.user?.email === adminEmail && value !== adminEmail) {
+          return 'You cannot change the admin password on the public demo!'
+        }
+        // call the payload default email validation
+        return validateEmail(value, args)
+      }
     },
     {
       name: 'roles',


### PR DESCRIPTION
Updating the admin email was still possible in the sanitize hook when changing the email without sending a new password. Now the password change is prevented in the hook and email is handled seperately in the validation logic.