### PR TITLE
Update *Nested Docs* link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ See the [Collections](https://payloadcms.com/docs/configuration/collections) doc
 
 - #### Categories
 
-  A taxonomy used to group posts or projects together. Categories can be nested inside of one another, for example "News > Technology". See the official [Payload Nested Docs Plugin](https://github.com/payloadcms/plugin-nested-docs) for more details.
+  A taxonomy used to group posts or projects together. Categories can be nested inside of one another, for example "News > Technology". See the official [Payload Nested Docs Plugin](https://payloadcms.com/docs/plugins/nested-docs) for more details.
 
 ### Globals
 


### PR DESCRIPTION
The old URL pointed to an [archived Github repository](https://github.com/payloadcms/plugin-nested-docs). The new URL points to the [docs page](https://payloadcms.com/docs/plugins/nested-docs).